### PR TITLE
improve customization options

### DIFF
--- a/keyboards/framework/config.h
+++ b/keyboards/framework/config.h
@@ -144,3 +144,6 @@
 //#define NO_ACTION_LAYER
 //#define NO_ACTION_TAPPING
 //#define NO_ACTION_ONESHOT
+
+/* Enable debug of matrix */
+//#define FW_DEBUG_MATRIX

--- a/keyboards/framework/framework.c
+++ b/keyboards/framework/framework.c
@@ -203,8 +203,8 @@ void post_process_record_kb(uint16_t keycode, keyrecord_t *record) {
             uint8_t s = rgb_matrix_get_sat();
             uint8_t v = get_backlight_level() * (255 / BACKLIGHT_LEVELS);
             rgb_matrix_sethsv(h, s, v);
-    }
 #endif
+    }
     post_process_record_user(keycode, record);
 }
 

--- a/keyboards/framework/framework.h
+++ b/keyboards/framework/framework.h
@@ -21,6 +21,7 @@ enum framework_keycodes {
   // Custom keycode to change screen modes (e.g. enable external screen)
   KC_SCRN = SAFE_RANGE,
   FN_LOCK,
+  FRAMEWORK_SAFE_RANGE,
 };
 
 extern bool bios_mode;

--- a/keyboards/framework/macropad/config.h
+++ b/keyboards/framework/macropad/config.h
@@ -14,3 +14,6 @@
 // Limit current to ensure max current draw is just about 500mA
 // when white at 100% brightness
 #define ISSI_GLOBALCURRENT 185
+
+// Backlight brightness step count
+#define BACKLIGHT_LEVELS 8

--- a/keyboards/framework/macropad/config.h
+++ b/keyboards/framework/macropad/config.h
@@ -14,6 +14,3 @@
 // Limit current to ensure max current draw is just about 500mA
 // when white at 100% brightness
 #define ISSI_GLOBALCURRENT 185
-
-// Backlight brightness step count
-#define BACKLIGHT_LEVELS 8

--- a/keyboards/framework/macropad/keymaps/default/config.h
+++ b/keyboards/framework/macropad/keymaps/default/config.h
@@ -1,0 +1,2 @@
+// Backlight brightness step count
+#define BACKLIGHT_LEVELS 6

--- a/keyboards/framework/macropad/keymaps/default/keymap.c
+++ b/keyboards/framework/macropad/keymaps/default/keymap.c
@@ -4,6 +4,12 @@
 #include QMK_KEYBOARD_H
 #include "factory.h"
 
+enum _layers {
+  _NUMLOCK,
+  _FN,
+  _FACTORY,
+};
+
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
      /*
      *         ┌────┬────┬────┬────┐
@@ -101,4 +107,13 @@ void enable_factory_mode(bool enable) {
         layer_on(_FACTORY);
     else
         layer_off(_FACTORY);
+}
+
+void keyboard_post_init_user(void) {
+    // Sync initial numlock state from the host
+    if (host_keyboard_led_state().num_lock) {
+        layer_on(_NUMLOCK);
+    } else {
+        layer_off(_FN);
+    }
 }

--- a/keyboards/framework/macropad/keymaps/esther/config.h
+++ b/keyboards/framework/macropad/keymaps/esther/config.h
@@ -1,0 +1,2 @@
+// Backlight brightness step count
+#define BACKLIGHT_LEVELS 6

--- a/keyboards/framework/macropad/macropad.c
+++ b/keyboards/framework/macropad/macropad.c
@@ -3,6 +3,7 @@
 
 #include QMK_KEYBOARD_H
 
+// clang-format off
 #if defined(RGB_MATRIX_ENABLE)
 const is31_led g_is31_leds[RGB_MATRIX_LED_COUNT] = {
 /* Refer to IS31 manual for these locations
@@ -80,13 +81,22 @@ led_config_t g_led_config = { {
   4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
   4, 4, 4, 4, 4, 4, 4, 4
 } };
-#endif
 
-void keyboard_post_init_user(void) {
-    // Sync initial numlock state from the host
-    if (host_keyboard_led_state().num_lock) {
-        layer_on(_NUMLOCK);
-    } else {
-        layer_off(_FN);
-    }
-}
+/*
+* LEDS:
+*         ┌────┬────┬────┬────┐
+*  4 keys │ 5  │ 2  │ 22 │ 17 │
+*         ├────┼────┼────┼────┤
+*  4 keys │ 4  │ 0  │ 2  │ 18 │
+*         ├────┼────┼────┼────┤
+*  4 keys │ 7  │ 1  │ 21 │ 16 │
+*         ├────┼────┼────┼────┤
+*  4 keys │ 6  │ 3  │ 23 │ 19 │
+*         ├────┼────┼────┼────┤
+*  4 keys │ 9  │ 11 │ 15 │ 13 │
+*         ├────┼────┼────┼────┤
+*  4 keys │ 8  │ 10 │ 14 │ 12 │
+*         └────┴────┴────┴────┴
+*/
+#endif
+// clang-format on

--- a/keyboards/framework/macropad/macropad.h
+++ b/keyboards/framework/macropad/macropad.h
@@ -15,9 +15,3 @@
   {  K108,    H1,    H2, KC_NO,    H4,  K107,  K109,  K110 }, \
   { KC_NO, KC_NO, KC_NO, KC_NO,    H3, KC_NO, KC_NO, KC_NO }, \
 }
-
-enum _layers {
-  _NUMLOCK,
-  _FN,
-  _FACTORY,
-};

--- a/keyboards/framework/matrix.c
+++ b/keyboards/framework/matrix.c
@@ -139,10 +139,12 @@ static bool interpret_adc_row(matrix_row_t cur_matrix[], adc10ksample_t voltage,
         key_state = true;
     }
 
+#if defined(FW_DEBUG_MATRIX)
     if (key_state) {
         uprintf("Col %d - Row %d - State: %d, Voltage: ", col, row, key_state);
         print_as_float(voltage);
     }
+#endif
 
 // Don't update  matrix on Pico to avoid messing with the debug system
 // Can't attach the matrix anyways
@@ -158,9 +160,11 @@ static bool interpret_adc_row(matrix_row_t cur_matrix[], adc10ksample_t voltage,
         new_row &= ~(1 << col);
     }
     changed = cur_matrix[row] != new_row;
+#if defined(FW_DEBUG_MATRIX)
     if (key_state) {
         uprintf("Keypress at KSO%d, KSI%d - %d.%dV\n", col, row, voltage/10000, voltage%10000);
     }
+#endif
     cur_matrix[row] = new_row;
 
     return changed;

--- a/keyboards/framework/readme.md
+++ b/keyboards/framework/readme.md
@@ -35,10 +35,11 @@ See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_to
 
 ## Bootloader
 
-Enter the bootloader in 3 ways:
+Enter the bootloader in 6 ways:
 
 * **On Framework Laptop 16 Keyboard**: Hold down left ALT and right ALT while installing the module
 * **On Framework Laptop 16 Numpad**: Hold down keys for 2 and 6 while installing the module
 * **On Raspberry Pi Pico**: Hold down bootsel button when plugging in
 * **Bootmagic reset**: Hold down the key at (0,0) in the matrix (usually the top left key or Escape) and plug in the keyboard
 * **Keycode in layout**: Press the key mapped to `QK_BOOT` if it is available
+* **QMK HID**: `qmk_hid --vid 32ac --pid <PID> via --bootloader`

--- a/keyboards/framework/readme.md
+++ b/keyboards/framework/readme.md
@@ -43,3 +43,22 @@ Enter the bootloader in 6 ways:
 * **Bootmagic reset**: Hold down the key at (0,0) in the matrix (usually the top left key or Escape) and plug in the keyboard
 * **Keycode in layout**: Press the key mapped to `QK_BOOT` if it is available
 * **QMK HID**: `qmk_hid --vid 32ac --pid <PID> via --bootloader`
+
+### Linux Flash
+
+Macropad example with QMK HID and wait for it to finish.
+Your OS may ask you to mount a new USB device, which you should do.
+
+```bash
+set -e
+echo "Compiling macropad"
+qmk compile -kb framework/macropad -km default -j 8
+
+echo "Flashing macropad"
+qmk flash -kb framework/macropad -km default &
+
+echo "Trigger bootloader"
+qmk_hid --vid 32ac --pid 0013 via --bootloader || true
+
+wait
+```

--- a/keyboards/framework/rules.mk
+++ b/keyboards/framework/rules.mk
@@ -24,3 +24,5 @@ SRC += dyn_serial.c factory.c
 DEFAULT_FOLDER = framework/ansi
 
 OPT_DEFS += -DCORTEX_ENABLE_WFI_IDLE=TRUE
+
+BOOTLOADER = rp2040


### PR DESCRIPTION
Changes:

- rework macropad backlight level handling
- disable debug output by default
- add FRAMEWORK_SAFE_RANGE to find first free KEYCODE
- set BOOTLOADER correct docu:
- qmk_hid bootloader trigger
- add LED num mapping