### PR TITLE
Align Code to QMK Coding Guidelines for keyboard_post_init_user()

### DIFF
--- a/keyboards/framework/framework.c
+++ b/keyboards/framework/framework.c
@@ -6,8 +6,6 @@
 #include "os_detection.h"
 
 void keyboard_post_init_kb(void) {
-  keyboard_post_init_user();
-
   // Enable debug output
   debug_enable = true;
   debug_matrix = true;

--- a/keyboards/framework/macropad/keymaps/default/keymap.c
+++ b/keyboards/framework/macropad/keymaps/default/keymap.c
@@ -4,6 +4,12 @@
 #include QMK_KEYBOARD_H
 #include "factory.h"
 
+enum _layers {
+  _NUMLOCK,
+  _FN,
+  _FACTORY,
+};
+
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
      /*
      *         ┌────┬────┬────┬────┐
@@ -101,4 +107,13 @@ void enable_factory_mode(bool enable) {
         layer_on(_FACTORY);
     else
         layer_off(_FACTORY);
+}
+
+void keyboard_post_init_user(void) {
+    // Sync initial numlock state from the host
+    if (host_keyboard_led_state().num_lock) {
+        layer_on(_NUMLOCK);
+    } else {
+        layer_off(_FN);
+    }
 }

--- a/keyboards/framework/macropad/keymaps/default/keymap.c
+++ b/keyboards/framework/macropad/keymaps/default/keymap.c
@@ -95,15 +95,12 @@ bool led_update_user(led_t led_state) {
     // Change layer if numlock state changes, either triggered by OS or
     // by numlock key on this keyboard
     static bool last_value = false;
-    if (led_state.num_lock) {
-        if(last_value != led_state.num_lock) {
+    if(last_value != led_state.num_lock) {
+        last_value = led_state.num_lock;
+        if (led_state.num_lock) {
             layer_off(_FN);
-            last_value = led_state.num_lock;
-        }
-    } else {
-        if(last_value != led_state.num_lock) {
+        } else {
             layer_on(_FN);
-            last_value = led_state.num_lock;
         }
     }
     return true;    

--- a/keyboards/framework/macropad/keymaps/default/keymap.c
+++ b/keyboards/framework/macropad/keymaps/default/keymap.c
@@ -94,12 +94,19 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 bool led_update_user(led_t led_state) {
     // Change layer if numlock state changes, either triggered by OS or
     // by numlock key on this keyboard
+    static bool last_value = false;
     if (led_state.num_lock) {
-        layer_off(_FN);
+        if(last_value != led_state.num_lock) {
+            layer_off(_FN);
+            last_value = led_state.num_lock;
+        }
     } else {
-        layer_on(_FN);
+        if(last_value != led_state.num_lock) {
+            layer_on(_FN);
+            last_value = led_state.num_lock;
+        }
     }
-    return true;
+    return true;    
 }
 
 void enable_factory_mode(bool enable) {

--- a/keyboards/framework/macropad/macropad.c
+++ b/keyboards/framework/macropad/macropad.c
@@ -81,12 +81,3 @@ led_config_t g_led_config = { {
   4, 4, 4, 4, 4, 4, 4, 4
 } };
 #endif
-
-void keyboard_post_init_user(void) {
-    // Sync initial numlock state from the host
-    if (host_keyboard_led_state().num_lock) {
-        layer_on(_NUMLOCK);
-    } else {
-        layer_off(_FN);
-    }
-}

--- a/keyboards/framework/macropad/macropad.h
+++ b/keyboards/framework/macropad/macropad.h
@@ -15,9 +15,3 @@
   {  K108,    H1,    H2, KC_NO,    H4,  K107,  K109,  K110 }, \
   { KC_NO, KC_NO, KC_NO, KC_NO,    H3, KC_NO, KC_NO, KC_NO }, \
 }
-
-enum _layers {
-  _NUMLOCK,
-  _FN,
-  _FACTORY,
-};

--- a/keyboards/framework/numpad/keymaps/default/keymap.c
+++ b/keyboards/framework/numpad/keymaps/default/keymap.c
@@ -3,6 +3,11 @@
 
 #include QMK_KEYBOARD_H
 
+enum _layers {
+  _NUMLOCK,
+  _FN
+};
+
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
      /*
      *         ┌────┬────┬────┬────┐
@@ -68,4 +73,13 @@ bool led_update_user(led_t led_state) {
         layer_on(_FN);
     }
     return true;
+}
+
+void keyboard_post_init_user(void) {
+    // Sync initial numlock state from the host
+    if (host_keyboard_led_state().num_lock) {
+        layer_on(_NUMLOCK);
+    } else {
+        layer_off(_FN);
+    }
 }

--- a/keyboards/framework/numpad/numpad.c
+++ b/keyboards/framework/numpad/numpad.c
@@ -3,12 +3,3 @@
 
 #include "quantum.h"
 #include "numpad.h"
-
-void keyboard_post_init_user(void) {
-    // Sync initial numlock state from the host
-    if (host_keyboard_led_state().num_lock) {
-        layer_on(_NUMLOCK);
-    } else {
-        layer_off(_FN);
-    }
-}

--- a/keyboards/framework/numpad/numpad.h
+++ b/keyboards/framework/numpad/numpad.h
@@ -17,7 +17,3 @@
   { KC_NO, KC_NO, KC_NO, KC_NO,    H3, KC_NO, KC_NO, KC_NO }, \
 }
 
-enum _layers {
-  _NUMLOCK,
-  _FN
-};


### PR DESCRIPTION
As mentioned in the [QMK Guidelines](https://docs.qmk.fm/hardware_keyboard_guidelines) all _user() functions should optimally  (in best case never) used by the keyboards to be available for the keymap / user to implement own stuff.

## Description

In your Macropad and Numpad keyboard you used keyboard_post_init_user() which should be used on keymap instead of keyboard level. For this i moved the functions to their respective default keymap, where they should be. The same or even more is important for layers which are specific for each keymap and should definitely only defined inside the respective keymaps (user-wide keymaps are an exception but since this is a keyboard folder, it is not applicable)

This Default keymap also serves as template to create an own keymap layout, so the code is still visible for everyone who wants to create or fork from it.

## Types of Changes

- [x] Core
- [X] Bugfix
- [x] Enhancement/optimization


## Issues Fixed or Closed by This PR

* Compiler Error about multiple definitions of keyboard_post_init_user()
* Move layout to keymap
* EDIT: added funtionality to avoid triggering an event-drive layer-function permanently due syncing of numlock

## Checklist

- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

PS: If approved and considered correct, pls ping me and i would like to fix the other _user() functions too, that i found. Want to avoid doing multiple PRs for nothing if you guys think otherwise and remodel it differently.
